### PR TITLE
Add self key with uri request

### DIFF
--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -86,6 +86,8 @@ func (t Templates) Render(ctx *authboss.Context, w http.ResponseWriter, r *http.
 		data.Merge(ctx.LayoutDataMaker(w, r))
 	}
 
+	data.MergeKV("self", r.URL.RequestURI())
+
 	if flash, ok := ctx.SessionStorer.Get(authboss.FlashSuccessKey); ok {
 		ctx.SessionStorer.Del(authboss.FlashSuccessKey)
 		data.MergeKV(authboss.FlashSuccessKey, flash)

--- a/internal/response/response_test.go
+++ b/internal/response/response_test.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/authboss.v0/internal/mocks"
 )
 
-var testViewTemplate = template.Must(template.New("").Parse(`{{.external}} {{.fun}} {{.flash_success}} {{.flash_error}} {{.xsrfName}} {{.xsrfToken}}`))
+var testViewTemplate = template.Must(template.New("").Parse(`{{.self}} {{.external}} {{.fun}} {{.flash_success}} {{.flash_error}} {{.xsrfName}} {{.xsrfToken}}`))
 var testEmailHTMLTemplate = template.Must(template.New("").Parse(`<h2>{{.}}</h2>`))
 var testEmailPlainTemplate = template.Must(template.New("").Parse(`i am a {{.}}`))
 
@@ -66,7 +66,7 @@ func TestTemplates_Render(t *testing.T) {
 	cookies.Put(authboss.FlashSuccessKey, "no")
 	cookies.Put(authboss.FlashErrorKey, "spoon")
 
-	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	r, _ := http.NewRequest("GET", "http://localhost?redirect=test", nil)
 	w := httptest.NewRecorder()
 	ctx, _ := ab.ContextFromRequest(r)
 	ctx.SessionStorer = cookies
@@ -80,7 +80,7 @@ func TestTemplates_Render(t *testing.T) {
 		t.Error(err)
 	}
 
-	if w.Body.String() != "there is no spoon do you think that's air you're breathing now?" {
+	if w.Body.String() != "/?redirect=test there is no spoon do you think that's air you're breathing now?" {
 		t.Error("Body was wrong:", w.Body.String())
 	}
 }


### PR DESCRIPTION
If I access ```http://localhost:3000/auth/login?redirect=/secure``` will not work, because the form submit to ```/auth/login``` ignoring query string.

This pull request make available ```self``` key, so you can use as bellow to make this works!
```
<form action={{.self}}>
...
<form>
```
