### PR TITLE
Fix a problem with not getting the correct Context on App Engine

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/net/context"
 )
 
 // Config holds all the configuration for both authboss and it's modules.
@@ -113,6 +114,8 @@ type Config struct {
 	// Mailer is the mailer being used to send e-mails out. Authboss defines two loggers for use
 	// LogMailer and SMTPMailer, the default is a LogMailer to io.Discard.
 	Mailer Mailer
+	// ContextProvider provides a context for a given request
+	ContextProvider func(*http.Request) context.Context
 }
 
 // Defaults sets the configuration's default values.
@@ -163,4 +166,7 @@ func (c *Config) Defaults() {
 
 	c.LogWriter = NewDefaultLogger()
 	c.Mailer = LogMailer(ioutil.Discard)
+	c.ContextProvider = func(req *http.Request) context.Context {
+		return context.TODO()
+	}
 }

--- a/internal/response/bindata.go
+++ b/internal/response/bindata.go
@@ -5,12 +5,12 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"strings"
-	"os"
-	"time"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
 func bindata_read(data []byte, name string) ([]byte, error) {
@@ -36,9 +36,9 @@ type asset struct {
 }
 
 type bindata_file_info struct {
-	name string
-	size int64
-	mode os.FileMode
+	name    string
+	size    int64
+	mode    os.FileMode
 	modTime time.Time
 }
 
@@ -77,7 +77,7 @@ func confirm_email_html_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "confirm_email.html.tpl", size: 108, mode: os.FileMode(438), modTime: time.Unix(1425861488, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -97,7 +97,7 @@ func confirm_email_txt_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "confirm_email.txt.tpl", size: 91, mode: os.FileMode(438), modTime: time.Unix(1425861619, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -117,7 +117,7 @@ func login_html_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "login.html.tpl", size: 746, mode: os.FileMode(438), modTime: time.Unix(1428692472, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -137,7 +137,7 @@ func recover_html_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "recover.html.tpl", size: 771, mode: os.FileMode(438), modTime: time.Unix(1425014937, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -157,7 +157,7 @@ func recover_complete_html_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "recover_complete.html.tpl", size: 752, mode: os.FileMode(438), modTime: time.Unix(1425060725, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -177,7 +177,7 @@ func recover_email_html_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "recover_email.html.tpl", size: 108, mode: os.FileMode(438), modTime: time.Unix(1425861503, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -197,7 +197,7 @@ func recover_email_txt_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "recover_email.txt.tpl", size: 91, mode: os.FileMode(438), modTime: time.Unix(1425861617, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -217,7 +217,7 @@ func register_html_tpl() (*asset, error) {
 	}
 
 	info := bindata_file_info{name: "register.html.tpl", size: 940, mode: os.FileMode(438), modTime: time.Unix(1424982621, 0)}
-	a := &asset{bytes: bytes, info:  info}
+	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
@@ -262,14 +262,14 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"confirm_email.html.tpl": confirm_email_html_tpl,
-	"confirm_email.txt.tpl": confirm_email_txt_tpl,
-	"login.html.tpl": login_html_tpl,
-	"recover.html.tpl": recover_html_tpl,
+	"confirm_email.html.tpl":    confirm_email_html_tpl,
+	"confirm_email.txt.tpl":     confirm_email_txt_tpl,
+	"login.html.tpl":            login_html_tpl,
+	"recover.html.tpl":          recover_html_tpl,
 	"recover_complete.html.tpl": recover_complete_html_tpl,
-	"recover_email.html.tpl": recover_email_html_tpl,
-	"recover_email.txt.tpl": recover_email_txt_tpl,
-	"register.html.tpl": register_html_tpl,
+	"recover_email.html.tpl":    recover_email_html_tpl,
+	"recover_email.txt.tpl":     recover_email_txt_tpl,
+	"register.html.tpl":         register_html_tpl,
 }
 
 // AssetDir returns the file names below a certain
@@ -308,71 +308,63 @@ func AssetDir(name string) ([]string, error) {
 }
 
 type _bintree_t struct {
-	Func func() (*asset, error)
+	Func     func() (*asset, error)
 	Children map[string]*_bintree_t
 }
+
 var _bintree = &_bintree_t{nil, map[string]*_bintree_t{
-	"confirm_email.html.tpl": &_bintree_t{confirm_email_html_tpl, map[string]*_bintree_t{
-	}},
-	"confirm_email.txt.tpl": &_bintree_t{confirm_email_txt_tpl, map[string]*_bintree_t{
-	}},
-	"login.html.tpl": &_bintree_t{login_html_tpl, map[string]*_bintree_t{
-	}},
-	"recover.html.tpl": &_bintree_t{recover_html_tpl, map[string]*_bintree_t{
-	}},
-	"recover_complete.html.tpl": &_bintree_t{recover_complete_html_tpl, map[string]*_bintree_t{
-	}},
-	"recover_email.html.tpl": &_bintree_t{recover_email_html_tpl, map[string]*_bintree_t{
-	}},
-	"recover_email.txt.tpl": &_bintree_t{recover_email_txt_tpl, map[string]*_bintree_t{
-	}},
-	"register.html.tpl": &_bintree_t{register_html_tpl, map[string]*_bintree_t{
-	}},
+	"confirm_email.html.tpl":    &_bintree_t{confirm_email_html_tpl, map[string]*_bintree_t{}},
+	"confirm_email.txt.tpl":     &_bintree_t{confirm_email_txt_tpl, map[string]*_bintree_t{}},
+	"login.html.tpl":            &_bintree_t{login_html_tpl, map[string]*_bintree_t{}},
+	"recover.html.tpl":          &_bintree_t{recover_html_tpl, map[string]*_bintree_t{}},
+	"recover_complete.html.tpl": &_bintree_t{recover_complete_html_tpl, map[string]*_bintree_t{}},
+	"recover_email.html.tpl":    &_bintree_t{recover_email_html_tpl, map[string]*_bintree_t{}},
+	"recover_email.txt.tpl":     &_bintree_t{recover_email_txt_tpl, map[string]*_bintree_t{}},
+	"register.html.tpl":         &_bintree_t{register_html_tpl, map[string]*_bintree_t{}},
 }}
 
 // Restore an asset under the given directory
 func RestoreAsset(dir, name string) error {
-        data, err := Asset(name)
-        if err != nil {
-                return err
-        }
-        info, err := AssetInfo(name)
-        if err != nil {
-                return err
-        }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
-        if err != nil {
-                return err
-        }
-        err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
-        if err != nil {
-                return err
-        }
-        err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
-        if err != nil {
-                return err
-        }
-        return nil
+	data, err := Asset(name)
+	if err != nil {
+		return err
+	}
+	info, err := AssetInfo(name)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	if err != nil {
+		return err
+	}
+	err = os.Chtimes(_filePath(dir, name), info.ModTime(), info.ModTime())
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Restore assets under the given directory recursively
 func RestoreAssets(dir, name string) error {
-        children, err := AssetDir(name)
-        if err != nil { // File
-                return RestoreAsset(dir, name)
-        } else { // Dir
-                for _, child := range children {
-                        err = RestoreAssets(dir, path.Join(name, child))
-                        if err != nil {
-                                return err
-                        }
-                }
-        }
-        return nil
+	children, err := AssetDir(name)
+	if err != nil { // File
+		return RestoreAsset(dir, name)
+	} else { // Dir
+		for _, child := range children {
+			err = RestoreAssets(dir, path.Join(name, child))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func _filePath(dir, name string) string {
-        cannonicalName := strings.Replace(name, "\\", "/", -1)
-        return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
+	cannonicalName := strings.Replace(name, "\\", "/", -1)
+	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/oauth2.go
+++ b/oauth2.go
@@ -3,8 +3,8 @@ package authboss
 import (
 	"net/url"
 
-	"golang.org/x/oauth2"
 	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
 )
 
 /*

--- a/oauth2.go
+++ b/oauth2.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/net/context"
 )
 
 /*
@@ -35,5 +36,5 @@ database/driver.Valuer.
 type OAuth2Provider struct {
 	OAuth2Config     *oauth2.Config
 	AdditionalParams url.Values
-	Callback         func(oauth2.Config, *oauth2.Token) (Attributes, error)
+	Callback         func(context.Context, oauth2.Config, *oauth2.Token) (Attributes, error)
 }

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -168,12 +168,12 @@ func (o *OAuth2) oauthCallback(ctx *authboss.Context, w http.ResponseWriter, r *
 
 	// Get the code
 	code := r.FormValue("code")
-	token, err := exchanger(cfg.OAuth2Config, oauth2.NoContext, code)
+	token, err := exchanger(cfg.OAuth2Config, o.Config.ContextProvider(r), code)
 	if err != nil {
 		return fmt.Errorf("Could not validate oauth2 code: %v", err)
 	}
 
-	user, err := cfg.Callback(*cfg.OAuth2Config, token)
+	user, err := cfg.Callback(o.Config.ContextProvider(r), *cfg.OAuth2Config, token)
 	if err != nil {
 		return err
 	}

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -143,7 +143,7 @@ func TestOAuthSuccess(t *testing.T) {
 		Expiry:       expiry,
 	}
 
-	fakeCallback := func(_ oauth2.Config, _ *oauth2.Token) (authboss.Attributes, error) {
+	fakeCallback := func(_ context.Context, _ oauth2.Config, _ *oauth2.Token) (authboss.Attributes, error) {
 		return authboss.Attributes{
 			authboss.StoreOAuth2UID: "uid",
 			authboss.StoreEmail:     "email",

--- a/oauth2/providers.go
+++ b/oauth2/providers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"gopkg.in/authboss.v0"
 )
@@ -22,8 +23,8 @@ type googleMeResponse struct {
 var clientGet = (*http.Client).Get
 
 // Google is a callback appropriate for use with Google's OAuth2 configuration.
-func Google(cfg oauth2.Config, token *oauth2.Token) (authboss.Attributes, error) {
-	client := cfg.Client(oauth2.NoContext, token)
+func Google(ctx context.Context, cfg oauth2.Config, token *oauth2.Token) (authboss.Attributes, error) {
+	client := cfg.Client(ctx, token)
 	resp, err := clientGet(client, googleInfoEndpoint)
 	if err != nil {
 		return nil, err
@@ -48,9 +49,9 @@ type facebookMeResponse struct {
 	Name  string `json:"name"`
 }
 
-// Google is a callback appropriate for use with Google's OAuth2 configuration.
-func Facebook(cfg oauth2.Config, token *oauth2.Token) (authboss.Attributes, error) {
-	client := cfg.Client(oauth2.NoContext, token)
+// Facebook is a callback appropriate for use with Facebook's OAuth2 configuration.
+func Facebook(ctx context.Context, cfg oauth2.Config, token *oauth2.Token) (authboss.Attributes, error) {
+	client := cfg.Client(ctx, token)
 	resp, err := clientGet(client, facebookInfoEndpoint)
 	if err != nil {
 		return nil, err

--- a/oauth2/providers.go
+++ b/oauth2/providers.go
@@ -48,7 +48,7 @@ type facebookMeResponse struct {
 	Name  string `json:"name"`
 }
 
-// Facebook is a callback appropriate for use with Facebook's OAuth2 configuration.
+// Google is a callback appropriate for use with Google's OAuth2 configuration.
 func Facebook(cfg oauth2.Config, token *oauth2.Token) (authboss.Attributes, error) {
 	client := cfg.Client(oauth2.NoContext, token)
 	resp, err := clientGet(client, facebookInfoEndpoint)

--- a/oauth2/providers_test.go
+++ b/oauth2/providers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"gopkg.in/authboss.v0"
 )
@@ -31,7 +32,7 @@ func TestGoogle(t *testing.T) {
 		Expiry:       time.Now().Add(60 * time.Minute),
 	}
 
-	user, err := Google(cfg, tok)
+	user, err := Google(context.TODO(), cfg, tok)
 	if err != nil {
 		t.Error(err)
 	}
@@ -64,7 +65,7 @@ func TestFacebook(t *testing.T) {
 		Expiry:       time.Now().Add(60 * time.Minute),
 	}
 
-	user, err := Facebook(cfg, tok)
+	user, err := Facebook(context.TODO(), cfg, tok)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This fixes #77 

At configuration step, one has to change ContextProvider:
```
ab.ContextProvider = func(r *http.Request) context.Context {
	return appengine.NewContext(r)
}
```