### PR TITLE
Added required handler for ListenAndServe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ if err := ab.Init(); err != nil {
 
 // Make sure to put authboss's router somewhere
 http.Handle("/authboss", ab.NewRouter())
-http.ListenAndServe(":8080",nil)
+http.ListenAndServe(":8080", nil)
 ```
 
 Once you've got this code set up, it's time to implement the use cases you care about.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ if err := ab.Init(); err != nil {
 
 // Make sure to put authboss's router somewhere
 http.Handle("/authboss", ab.NewRouter())
-http.ListenAndServe(":8080")
+http.ListenAndServe(":8080",nil)
 ```
 
 Once you've got this code set up, it's time to implement the use cases you care about.


### PR DESCRIPTION
http.ListenAndServe requires two arguments, the second one can be nil,
but must be present.  https://golang.org/pkg/net/http/#ListenAndServe

Omitting it, even in just documention code snippets like ths one,
might confuse people just learning (like myself).