### PR TITLE
Fix func Bind not handling sql.Nullstring from nil. Closes #110.

### DIFF
--- a/storer.go
+++ b/storer.go
@@ -293,9 +293,11 @@ func (a Attributes) Bind(strct interface{}, ignoreMissing bool) error {
 				return errors.New("Bind: Was a scanner without a Scan method")
 			}
 
-			rvals := method.Call([]reflect.Value{reflect.ValueOf(v)})
-			if err, ok := rvals[0].Interface().(error); ok && err != nil {
-				return err
+			if v != nil {
+				rvals := method.Call([]reflect.Value{reflect.ValueOf(v)})
+				if err, ok := rvals[0].Interface().(error); ok && err != nil {
+					return err
+				}
 			}
 
 			continue


### PR DESCRIPTION
Also fixes behavior for sql.NullInt64, sql.NullFloat64, sql.NullBool.