### PR TITLE
allow to customize if the user is going to be signed in after confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ See also: [Validation](#validation)
 - Confirmed (bool)
 
 **How it works:** After registration, the user will be informed they have an e-mail waiting for them. They click the link
-provided in the e-mail and their account becomes confirmed, they will automatically be logged in and redirected to RegisterOKPath.
+provided in the e-mail and their account becomes confirmed, they will automatically be redirected to RegisterOKPath
+and logged in if the AllowInsecureLoginAfterConfirm property is set to true.
+.
 
 ## <a name="recover"></a> Password Recovery
 **Requirements:**

--- a/README.md
+++ b/README.md
@@ -251,9 +251,10 @@ See also: [Validation](#validation)
 - Confirmed (bool)
 
 **How it works:** After registration, the user will be informed they have an e-mail waiting for them. They click the link
-provided in the e-mail and their account becomes confirmed, they will automatically be redirected to RegisterOKPath
-and logged in if the AllowInsecureLoginAfterConfirm property is set to true.
-.
+provided in the e-mail and their account becomes confirmed, they will automatically be redirected to RegisterOKPath in the
+default settings. If the AllowInsecureLoginAfterConfirm property is set to true, the user will also be automatically
+logged in. The default for this property is set to false.
+
 
 ## <a name="recover"></a> Password Recovery
 **Requirements:**

--- a/config.go
+++ b/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	// authboss.StoreEmail, authboss.StoreUsername (StoreEmail is default)
 	PrimaryID string
 
+	// Allow the user to be automatically signed in after confirm his account
+	AllowInsecureLoginAfterConfirm bool
+
 	// Layout that all authboss views will be inserted into.
 	Layout *template.Template
 	// LayoutHTMLEmail is for emails going out in HTML form, authbosses e-mail templates

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -188,16 +188,16 @@ func (c *Confirm) confirmHandler(ctx *authboss.Context, w http.ResponseWriter, r
 	ctx.User[StoreConfirmToken] = ""
 	ctx.User[StoreConfirmed] = true
 
-	key, err := ctx.User.StringErr(c.PrimaryID)
-	if err != nil {
-		return err
-	}
-
 	if err := ctx.SaveUser(); err != nil {
 		return err
 	}
-
-	ctx.SessionStorer.Put(authboss.SessionKey, key)
+	if c.Authboss.AllowInsecureLoginAfterConfirm {
+		key, err := ctx.User.StringErr(c.PrimaryID)
+		if err != nil {
+			return err
+		}
+		ctx.SessionStorer.Put(authboss.SessionKey, key)
+	}
 	response.Redirect(ctx, w, r, c.RegisterOKPath, "You have successfully confirmed your account.", "", true)
 
 	return nil

--- a/confirm/confirm_test.go
+++ b/confirm/confirm_test.go
@@ -212,6 +212,7 @@ func TestConfirm_Confirm(t *testing.T) {
 	session := mocks.NewMockClientStorer()
 	ctx.User = user
 	ctx.SessionStorer = session
+	ctx.AllowInsecureLoginAfterConfirm = false
 
 	c.confirmHandler(ctx, w, r)
 	if w.Code != http.StatusFound {
@@ -232,9 +233,10 @@ func TestConfirm_Confirm(t *testing.T) {
 		t.Error("Confirm token should have been wiped out.")
 	}
 
-	if key, ok := ctx.SessionStorer.Get(authboss.SessionKey); !ok || len(key) == 0 {
-		t.Error("Should have logged the user in.")
+	if _, ok := ctx.SessionStorer.Get(authboss.SessionKey); ok {
+		t.Error("Should not have logged the user in since AllowInsecureLoginAfterConfirm is false.")
 	}
+
 	if success, ok := ctx.SessionStorer.Get(authboss.FlashSuccessKey); !ok || len(success) == 0 {
 		t.Error("Should have left a nice message.")
 	}


### PR DESCRIPTION
this pr is related with the issue https://github.com/go-authboss/authboss/issues/123.

Now we can customize if we want our user being signed in after confirming his account